### PR TITLE
Handle gmail connection and email display

### DIFF
--- a/svelte-app/src/routes/+layout.svelte
+++ b/svelte-app/src/routes/+layout.svelte
@@ -45,6 +45,21 @@
     import('$lib/db/backups').then((m) => m.maybeCreateWeeklySnapshot());
     // Keep optional: legacy local snooze viewer; safe if empty
     import('$lib/stores/snooze').then((m)=>m.loadSnoozes());
+
+    // Ensure first-run shows connect wizard at root
+    (async () => {
+      try {
+        const { getDB } = await import('$lib/db/indexeddb');
+        const db = await getDB();
+        const account = await db.get('auth', 'me');
+        if (!account) {
+          const target = (base || '') + '/';
+          if (location.pathname !== target) {
+            location.href = target;
+          }
+        }
+      } catch (_) {}
+    })();
   }
 
   let { children }: { children: Snippet } = $props();


### PR DESCRIPTION
Ensure the Gmail connection wizard reliably appears on first app open by redirecting to the root if no account is found.

The existing logic in `src/routes/+page.svelte` to show the wizard was sometimes bypassed on initial load, especially if the app landed on a different route. This change in the root layout ensures that any unauthenticated client-side load is always redirected to the root page, guaranteeing the wizard's appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8253c08-4aa6-451a-b980-29350f6dd201">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8253c08-4aa6-451a-b980-29350f6dd201">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

