### PR TITLE
Fix archive and delete animation issues

### DIFF
--- a/svelte-app/src/lib/utils/ThreadListRow.svelte
+++ b/svelte-app/src/lib/utils/ThreadListRow.svelte
@@ -169,8 +169,8 @@
   <div class="bg" aria-hidden="true" style={`pointer-events:${pendingLabel ? 'auto' : 'none'}`}> 
     <div class="left" style={`background:${pendingRemove ? 'rgb(var(--m3-scheme-error-container))' : 'rgb(var(--m3-scheme-secondary-container))'}; color:${pendingRemove ? 'rgb(var(--m3-scheme-on-error-container))' : 'rgb(var(--m3-scheme-on-secondary-container))'}`}>
       {#if pendingLabel}
-        <div class="pending-wrap">
-          <span class="pending-label">{pendingLabel}</span>
+        <div class="pending-wrap" role="status" aria-live="polite">
+          <span class="pending-label m3-font-label-large">{pendingLabel}</span>
           <Button variant="text" class="undo-btn" onclick={onUndoBgClick}>Undo</Button>
         </div>
       {:else}
@@ -213,19 +213,21 @@
   .bg .left {
     background: rgb(var(--m3-scheme-secondary-container));
     padding: 0.25rem 0.5rem;
-    border-radius: 0.5rem;
+    border-radius: var(--m3-util-rounding-extra-small);
     min-width: 5rem;
     text-align: center;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+    box-shadow: var(--m3-util-elevation-1);
   }
   .bg .right {
     background: rgb(var(--m3-scheme-tertiary-container));
     padding: 0.25rem 0.5rem;
-    border-radius: 0.5rem;
+    border-radius: var(--m3-util-rounding-extra-small);
     min-width: 5rem;
     text-align: center;
+    box-shadow: var(--m3-util-elevation-1);
   }
   .pending-wrap { display: inline-flex; align-items: center; gap: 0.5rem; }
   /* Make the inline Undo button MD3-compliant for container backgrounds */
@@ -235,6 +237,8 @@
     background: transparent;
     color: inherit !important;
     box-shadow: none;
+    border-radius: var(--m3-util-rounding-small);
+    min-width: auto;
   }
   .fg {
     position: relative;

--- a/svelte-app/src/lib/utils/VirtualList.svelte
+++ b/svelte-app/src/lib/utils/VirtualList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Snippet } from 'svelte';
-  let { items, rowHeight = 64, overscan = 6, children }: { items: any[]; rowHeight?: number; overscan?: number; children: Snippet<[any, number]> } = $props();
+  let { items, rowHeight = 64, overscan = 6, children, getKey }: { items: any[]; rowHeight?: number; overscan?: number; children: Snippet<[any, number]>; getKey?: (item: any, index: number) => string | number } = $props();
   let container: HTMLDivElement | null = null;
   let height = 400;
   let scrollTop = 0;
@@ -96,7 +96,7 @@
 
 <div bind:this={container} onscroll={onScroll} style="overflow: auto; will-change: transform; contain: strict; height: 100%; min-height: 0;">
   <div style={`height:${total}px; position: relative;`}>
-    {#each slice as item, i}
+    {#each slice as item, i (getKey ? getKey(item, startIndex + i) : (startIndex + i))}
       {@const idx = startIndex + i}
       <div class="row" style={`position:absolute; top:${offsets[idx]}px; left:0; right:0; min-height:${rowHeight}px;`} use:measureRow={idx}>
         {@render children(item, idx)}

--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -346,7 +346,7 @@
     </Card>
   {/if}
   <div style="height:70vh">
-    <VirtualList items={visibleThreads} rowHeight={68}>
+    <VirtualList items={visibleThreads} rowHeight={68} getKey={(t) => t.threadId}>
       {#snippet children(item: import('$lib/types').GmailThread)}
       <ThreadListRow thread={item} />
       {/snippet}

--- a/svelte-app/src/routes/snoozed/+page.svelte
+++ b/svelte-app/src/routes/snoozed/+page.svelte
@@ -151,7 +151,7 @@
 {:else}
   <button disabled={!nextPageToken || syncing} on:click={loadMore}>{syncing ? 'Loading…' : 'Load more'}</button>
   <div style="height:70vh">
-    <VirtualList items={$threadsStore} rowHeight={68}>
+    <VirtualList items={$threadsStore} rowHeight={68} getKey={(t) => t.threadId}>
       {#snippet children(item: import('$lib/types').GmailThread)}
         <ThreadListRow thread={item} />
       {/snippet}


### PR DESCRIPTION
Implement stable keys for virtual lists and update trailing action UI to prevent list jumps and ensure MD3 compliance.

Previously, deleting an item with a trailing action caused the subsequent item to visually 'jump' into the deleted item's position during the animation, creating a confusing user experience. This was due to the virtual list re-rendering items by index. By introducing stable keys (using `threadId`), items now maintain their identity, allowing for a smooth collapse animation where the deleted item correctly disappears.

---
<a href="https://cursor.com/background-agent?bcId=bc-2878effe-d24b-44cc-8805-f5dd1d508e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2878effe-d24b-44cc-8805-f5dd1d508e21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

