### PR TITLE
Close overflow menu on outside click

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -72,6 +72,19 @@
       showSnackbar({ message: ok ? 'Diagnostics copied' : 'Failed to copy diagnostics', closable: true });
     }
   }
+
+  // Close overflow menu when clicking outside of it
+  $effect(() => {
+    function handleWindowClick(e: MouseEvent) {
+      const d = overflowDetails;
+      if (!d || !d.open) return;
+      const target = e.target as Node | null;
+      if (target && (d === target || d.contains(target))) return;
+      d.open = false;
+    }
+    window.addEventListener('click', handleWindowClick);
+    return () => window.removeEventListener('click', handleWindowClick);
+  });
 </script>
 
 <div class="topbar">


### PR DESCRIPTION
Add a click-outside handler to close the overflow menu when clicking elsewhere.

---
<a href="https://cursor.com/background-agent?bcId=bc-b527e132-eff9-4e21-a9d5-1137f977908f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b527e132-eff9-4e21-a9d5-1137f977908f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

