### PR TITLE
Add about item to overflow menu

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -10,13 +10,17 @@
   import Icon from '$lib/misc/_icon.svelte';
   import { show as showSnackbar } from '$lib/containers/snackbar';
   import { copyGmailDiagnosticsToClipboard } from '$lib/gmail/api';
+  import Dialog from '$lib/containers/Dialog.svelte';
+  import { appVersion, buildId } from '$lib/utils/version';
   import iconSearch from '@ktibow/iconset-material-symbols/search';
   import iconMore from '@ktibow/iconset-material-symbols/more-vert';
+  import iconInfo from '@ktibow/iconset-material-symbols/info';
   import iconUndo from '@ktibow/iconset-material-symbols/undo';
   import iconRedo from '@ktibow/iconset-material-symbols/redo';
   import iconSync from '@ktibow/iconset-material-symbols/sync';
   let { onSyncNow }: { onSyncNow?: () => void } = $props();
   let overflowDetails: HTMLDetailsElement;
+  let aboutOpen = $state(false);
   function toggleOverflow(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
@@ -167,8 +171,20 @@
         <MenuItem onclick={() => (location.href = '/settings')}>Settings</MenuItem>
         <MenuItem onclick={doSync}>Sync now</MenuItem>
         <MenuItem onclick={async()=>{ const m = await import('$lib/db/backups'); await m.createBackup(); await m.pruneOldBackups(4); }}>Create backup</MenuItem>
+        <MenuItem onclick={() => { aboutOpen = true; }}>About</MenuItem>
       </Menu>
     </details>
+    <Dialog icon={iconInfo} headline="About" bind:open={aboutOpen} closeOnClick={false}>
+      {#snippet children()}
+        <div class="about">
+          <div class="row"><span class="k">Version</span><span class="v">{appVersion}</span></div>
+          <div class="row"><span class="k">Build</span><span class="v">{buildId}</span></div>
+        </div>
+      {/snippet}
+      {#snippet buttons()}
+        <Button variant="text" onclick={() => (aboutOpen = false)}>Close</Button>
+      {/snippet}
+    </Dialog>
   </div>
 </div>
 
@@ -193,6 +209,10 @@
   .summary-btn { cursor: pointer; }
   .overflow[open] > :global(.m3-container) { position:absolute; right:0; margin-top:0.25rem; }
   .last-sync { color: rgb(var(--m3-scheme-on-surface-variant)); margin-inline-start: 0.25rem; }
+  .about { display:flex; flex-direction:column; gap:0.5rem; }
+  .about .row { display:flex; justify-content:space-between; gap:1rem; }
+  .about .k { color: rgb(var(--m3-scheme-on-surface-variant)); }
+  .about .v { color: rgb(var(--m3-scheme-on-surface)); font-variant-numeric: tabular-nums; }
 </style>
 
 

--- a/svelte-app/src/lib/utils/version.ts
+++ b/svelte-app/src/lib/utils/version.ts
@@ -1,0 +1,9 @@
+import pkg from '../../../package.json' assert { type: 'json' };
+
+export const appVersion: string = pkg.version as string;
+
+// Build identifier: prefer Vite-provided env or fallback to date-based string
+const fromEnv = (import.meta as any).env?.VITE_BUILD_ID || (globalThis as any).VITE_BUILD_ID;
+export const buildId: string = typeof fromEnv === 'string' && fromEnv.length > 0
+	? fromEnv
+	: new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 14);


### PR DESCRIPTION
Add an 'About' item to the overflow menu to display the app version and build ID in an MD3 dialog.

The version is read from `package.json`, and the build ID is sourced from the `VITE_BUILD_ID` environment variable, falling back to a timestamp if not provided. This provides users with essential application information.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6f8adc7-40ac-481b-8717-3ba642dd1330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6f8adc7-40ac-481b-8717-3ba642dd1330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

