### PR TITLE
Investigate pink background element in trailing actions

### DIFF
--- a/svelte-app/src/lib/utils/ThreadListRow.svelte
+++ b/svelte-app/src/lib/utils/ThreadListRow.svelte
@@ -191,6 +191,7 @@
      onpointerup={onPointerUp}
 >
   <div class="bg" aria-hidden="true" style={`pointer-events:${pendingLabel ? 'auto' : 'none'}`}> 
+    {#if pendingLabel || dx > 0}
     <div class="left" style={`background:${pendingRemove ? 'rgb(var(--m3-scheme-error-container))' : 'rgb(var(--m3-scheme-secondary-container))'}; color:${pendingRemove ? 'rgb(var(--m3-scheme-on-error-container))' : 'rgb(var(--m3-scheme-on-secondary-container))'}`}>
       {#if pendingLabel}
         <div class="pending-wrap" role="status" aria-live="polite">
@@ -201,7 +202,10 @@
         {dx > 40 ? 'Archive' : ''}
       {/if}
     </div>
+    {/if}
+    {#if dx < 0}
     <div class="right">{dx < -40 ? '1h' : ''}</div>
+    {/if}
   </div>
   <div class="fg" style={`transform: translateX(${dx}px); transition: ${animating ? 'transform 180ms var(--m3-util-easing-fast)' : 'none'};`} in:fade={{ duration: 120 }} out:fade={{ duration: 180 }}>
     <ListItem


### PR DESCRIPTION
Conditionally render row swipe background pills to prevent an empty pink bar from appearing at rest.

---
<a href="https://cursor.com/background-agent?bcId=bc-02248812-ee40-453c-9e80-56c2e9d5e262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02248812-ee40-453c-9e80-56c2e9d5e262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

