### PR TITLE
Consolidate sync and refresh button

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -134,29 +134,19 @@
     <div class="search-field">
       <TextField label="Search" leadingIcon={iconSearch} bind:value={search} />
     </div>
-    <SplitButton variant="outlined" x="inner" y="down" onclick={doSync}>
+    <Button variant="outlined" iconType="left" onclick={doSync}>
       {#snippet children()}
         <Icon icon={iconSync} />
         <span class="label">
           {#if $syncState.pendingOps > 0}
             {$syncState.pendingOps} pending
-          {:else}
-            Synced
           {/if}
         </span>
         {#if !$syncState.pendingOps}
-          <span class="last-sync m3-font-label-small">• {formatLastSync($syncState.lastUpdatedAt)}</span>
+          <span class="last-sync m3-font-label-small">{formatLastSync($syncState.lastUpdatedAt)}</span>
         {/if}
       {/snippet}
-      {#snippet menu()}
-        <Menu>
-          <MenuItem onclick={doSync}>Sync now</MenuItem>
-          {#if $syncState.lastError}
-            <MenuItem onclick={onPendingChipClick}>Copy diagnostics</MenuItem>
-          {/if}
-        </Menu>
-      {/snippet}
-    </SplitButton>
+    </Button>
     <details class="overflow" bind:this={overflowDetails}>
       <summary aria-label="More actions" class="summary-btn" onclick={toggleOverflow}>
         <Button variant="text" iconType="full" aria-label="More actions">


### PR DESCRIPTION
Replaced the sync split button with a single MD3 button to simplify the UI, combine sync and refresh actions, and remove the "Synced" label.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fbfb9e6-2668-403b-892c-f09fe4ddd5e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fbfb9e6-2668-403b-892c-f09fe4ddd5e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

