### PR TITLE
Cache inbox for faster thread navigation

### DIFF
--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -65,27 +65,33 @@
 
   onMount(() => {
     const unsub = authState.subscribe((s) => (ready = s.ready));
+    if (($threadsStore || []).length) loading = false;
     (async () => {
+      let hadCache = false;
       try {
         CLIENT_ID = CLIENT_ID || resolveGoogleClientId() as string;
         await initAuth(CLIENT_ID);
         // Load settings first for snooze defaults
         const { loadSettings } = await import('$lib/stores/settings');
         await loadSettings();
-        await hydrateFromCache();
+        hadCache = await hydrateFromCache();
+        if (hadCache) loading = false;
         navigator.serviceWorker?.addEventListener('message', (e: MessageEvent) => {
           if ((e.data && e.data.type) === 'SYNC_TICK') void hydrateFromCache();
         });
-        // Attempt initial remote hydrate
+        // Attempt initial remote hydrate without blocking UI if cache exists
         try {
+          syncing = true;
           await hydrate();
         } catch (e) {
           setApiError(e);
+        } finally {
+          syncing = false;
         }
       } catch (e) {
         setApiError(e);
       } finally {
-        loading = false;
+        if (!hadCache) loading = false;
       }
     })();
     return () => unsub();
@@ -129,16 +135,19 @@
 
   async function hydrateFromCache() {
     const db = await getDB();
+    let hasCached = false;
     const cachedLabels = await db.getAll('labels');
-    if (cachedLabels?.length) labelsStore.set(cachedLabels);
+    if (cachedLabels?.length) { labelsStore.set(cachedLabels); hasCached = true; }
     const cachedThreads = await db.getAll('threads');
-    if (cachedThreads?.length) threadsStore.set(cachedThreads);
+    if (cachedThreads?.length) { threadsStore.set(cachedThreads); hasCached = true; }
     const cachedMessages = await db.getAll('messages');
     if (cachedMessages?.length) {
       const dict: Record<string, import('$lib/types').GmailMessage> = {};
       for (const m of cachedMessages) dict[m.id] = m;
       messagesStore.set(dict);
+      hasCached = true;
     }
+    return hasCached;
   }
 
   async function hydrate() {


### PR DESCRIPTION
Render cached inbox data immediately to provide an instant view when returning from a thread.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9ddbdc5-6dae-46ef-954a-d556b051704f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9ddbdc5-6dae-46ef-954a-d556b051704f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

