### PR TITLE
Move snackbar lower on screen

### DIFF
--- a/svelte-app/src/lib/containers/Snackbar.svelte
+++ b/svelte-app/src/lib/containers/Snackbar.svelte
@@ -86,7 +86,7 @@
   .holder {
     position: fixed;
     padding-bottom: 1rem;
-    bottom: var(--m3-util-bottom-offset);
+    bottom: max(calc(var(--m3-util-bottom-offset) - 1rem), 0.5rem);
     left: 50%;
     transform: translate(-50%, 0);
     z-index: 3;


### PR DESCRIPTION
Adjust Snackbar position to move it lower on the screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-200265d4-5513-4fd8-9f7f-3108cd327dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-200265d4-5513-4fd8-9f7f-3108cd327dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

