### PR TITLE
Fetch all email counts for badge

### DIFF
--- a/svelte-app/src/lib/gmail/api.ts
+++ b/svelte-app/src/lib/gmail/api.ts
@@ -310,6 +310,20 @@ export async function getProfile(): Promise<{ emailAddress: string; messagesTota
   return data;
 }
 
+export async function getLabel(labelId: string): Promise<GmailLabel & { id: string }> {
+  type LabelResponse = GmailLabel & {
+    messageListVisibility?: string;
+    labelListVisibility?: string;
+    messagesTotal?: number;
+    messagesUnread?: number;
+    threadsTotal?: number;
+    threadsUnread?: number;
+  };
+  const data = await api<LabelResponse>(`/labels/${encodeURIComponent(labelId)}`);
+  pushDiag({ type: 'label', id: data.id, name: (data as any)?.name, messagesTotal: (data as any)?.messagesTotal, threadsTotal: (data as any)?.threadsTotal, messagesUnread: (data as any)?.messagesUnread, threadsUnread: (data as any)?.threadsUnread });
+  return data as GmailLabel & { id: string };
+}
+
 function summarizeListData(data: unknown) {
   try {
     const d: any = data || {};

--- a/svelte-app/src/lib/types.ts
+++ b/svelte-app/src/lib/types.ts
@@ -1,6 +1,12 @@
 // Core shared types for the Gmail PWA client
 
-export type GmailLabel = { id: string; name: string; type: "system" | "user" };
+export type GmailLabel = { id: string; name: string; type: "system" | "user" } & {
+  // Optional stats provided by Gmail labels.get when requested
+  messagesTotal?: number;
+  messagesUnread?: number;
+  threadsTotal?: number;
+  threadsUnread?: number;
+};
 
 export type GmailMessage = {
   id: string;


### PR DESCRIPTION
Update email statistics badges to show full counts using Gmail label stats, even for unloaded emails.

---
<a href="https://cursor.com/background-agent?bcId=bc-df12099f-f61c-4441-aece-eb70ba39c77b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df12099f-f61c-4441-aece-eb70ba39c77b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

