### PR TITLE
Fetch and display inbox messages

### DIFF
--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -43,7 +43,7 @@
   const inboxCount = $derived(inboxThreads.length);
   const visibleThreadsCount = $derived(visibleThreads?.length || 0);
   const unreadCount = $derived(inboxThreads.filter((t) => (t.labelIds || []).includes('UNREAD')).length);
-  const soonSnoozedCount = $derived(() => {
+  const soonSnoozedCount = $derived.by(() => {
     try {
       const now = Date.now();
       const cutoff = now + 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Update `soonSnoozedCount` to use `$derived.by` to fix a visual bug where the function source was rendered in the "Soon snoozed" badge.

The "Soon snoozed" chip was rendering the function source instead of its computed numeric value because it was using the old Svelte `$derived(() => …)` API. Updating it to `$derived.by(() => …)` ensures the badge displays a number, resolving the unexpected background artifact in the top bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-635f35f0-aeca-45d0-a3c5-e51c22b2854c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-635f35f0-aeca-45d0-a3c5-e51c22b2854c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

