### PR TITLE
Explain create task in thread view

### DIFF
--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -137,7 +137,18 @@
     try {
       // Desktop: copy; user can paste into their task file
       await navigator.clipboard.writeText(line);
-      alert('Task line copied to clipboard.');
+      // Verify clipboard actually contains the line; if read is blocked or mismatch, fallback to showing the text
+      try {
+        const readBack = await navigator.clipboard.readText();
+        if (readBack === line) {
+          alert('Task line copied to clipboard.');
+        } else {
+          alert(line);
+        }
+      } catch (_) {
+        // If we cannot read the clipboard (permission), show the line for manual copy
+        alert(line);
+      }
     } catch { alert(line); }
   }
 </script>


### PR DESCRIPTION
Verify clipboard write in 'Create Task' to ensure success message accuracy and provide a fallback for manual copy if the write fails or is blocked.

Previously, the 'Create Task' action would always show a "Task line copied to clipboard" message, even if the clipboard write operation failed or was blocked by browser permissions. This led to user confusion when the clipboard did not contain the expected data. The updated code now attempts to read back the clipboard content after writing. If the read content matches the intended task line, the success message is shown. Otherwise, or if reading the clipboard is not permitted, the task line itself is displayed in an alert, allowing the user to manually copy it.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf7200e1-49c4-4c32-818b-f2a753ae88eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf7200e1-49c4-4c32-818b-f2a753ae88eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

