### PR TITLE
Fix broken top bar affecting task list

### DIFF
--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -45,20 +45,21 @@
   const inboxCount = $derived(inboxLabelStats?.threadsTotal ?? inboxThreads.length);
   const visibleThreadsCount = $derived(visibleThreads?.length || 0);
   const unreadCount = $derived(inboxLabelStats?.threadsUnread ?? inboxThreads.filter((t) => (t.labelIds || []).includes('UNREAD')).length);
-  const soonSnoozedCount = $derived(() => {
-    try {
-      const now = Date.now();
-      const cutoff = now + 24 * 60 * 60 * 1000;
-      const map = $snoozeByThread || {};
-      let count = 0;
-      for (const info of Object.values(map)) {
-        if (info && typeof info.dueAtUtc === 'number' && info.dueAtUtc <= cutoff) count++;
+  const soonSnoozedCount = $derived(
+    (() => {
+      try {
+        const cutoff = Date.now() + 24 * 60 * 60 * 1000;
+        const map = $snoozeByThread || {};
+        let count = 0;
+        for (const info of Object.values(map)) {
+          if (info && typeof info.dueAtUtc === 'number' && info.dueAtUtc <= cutoff) count++;
+        }
+        return count;
+      } catch {
+        return 0;
       }
-      return count;
-    } catch {
-      return 0;
-    }
-  });
+    })()
+  );
   $effect(() => {
     // Log UI-level diagnostics in dev builds only
     try {


### PR DESCRIPTION
Correct `soonSnoozedCount` derivation in inbox page to fix UI layout.

The previous implementation defined `soonSnoozedCount` as `$derived(() => { ... })`. In Svelte 5 runes, `$derived` expects a value, not a function, which caused the function's source code to be rendered directly into the DOM and break the layout of the top bar chips.

---
<a href="https://cursor.com/background-agent?bcId=bc-b111e1bc-9c7a-4e19-ae1e-1a3020e0ab51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b111e1bc-9c7a-4e19-ae1e-1a3020e0ab51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

