### PR TITLE
Remove bottom tabs and use MD3 buttons

### DIFF
--- a/svelte-app/src/routes/+layout.svelte
+++ b/svelte-app/src/routes/+layout.svelte
@@ -253,15 +253,12 @@
   }
   @media (width < 52.5rem) {
     .container {
-      grid-template-rows: 1fr auto;
-      --m3-util-bottom-offset: 5rem;
+      grid-template-rows: 1fr;
+      /* Remove extra bottom spacing since bottom tabs are removed */
+      --m3-util-bottom-offset: unset;
     }
     .sidebar {
-      flex-direction: column;
-      bottom: 0;
-      width: 100%;
-      z-index: 3;
-      grid-row: 2;
+      display: none;
     }
   }
   @media (width >= 52.5rem) {

--- a/svelte-app/src/routes/snoozed/+page.svelte
+++ b/svelte-app/src/routes/snoozed/+page.svelte
@@ -8,6 +8,7 @@
   import { settings } from '$lib/stores/settings';
   import VirtualList from '$lib/utils/VirtualList.svelte';
   import ThreadListRow from '$lib/utils/ThreadListRow.svelte';
+  import Button from '$lib/buttons/Button.svelte';
 
   let loading = true;
   let error: string | null = null;
@@ -149,7 +150,7 @@
 {:else if !activeLabelId}
   <p>No snooze labels configured. Map them in Settings.</p>
 {:else}
-  <button disabled={!nextPageToken || syncing} on:click={loadMore}>{syncing ? 'Loading…' : 'Load more'}</button>
+  <Button variant="outlined" disabled={!nextPageToken || syncing} onclick={loadMore}>{syncing ? 'Loading…' : 'Load more'}</Button>
   <div style="height:70vh">
     <VirtualList items={$threadsStore} rowHeight={68} getKey={(t) => t.threadId}>
       {#snippet children(item: import('$lib/types').GmailThread)}


### PR DESCRIPTION
Remove bottom tabs from mobile layout and replace a raw button with an MD3 component.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d67469e-8be7-44e7-b5b1-2525683feb09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d67469e-8be7-44e7-b5b1-2525683feb09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

