### PR TITLE
Add snooze split button with dropdown

### DIFF
--- a/svelte-app/src/lib/snooze/SnoozePanel.svelte
+++ b/svelte-app/src/lib/snooze/SnoozePanel.svelte
@@ -2,7 +2,7 @@
   import type { Snippet } from 'svelte';
   import { get } from 'svelte/store';
   import { settings } from '$lib/stores/settings';
-  import { resolveRule } from '$lib/snooze/rules';
+  import { resolveRule, normalizeRuleKey } from '$lib/snooze/rules';
   import Chip from '$lib/forms/Chip.svelte';
 
   export let onSelect: (ruleKey: string) => void;
@@ -32,7 +32,7 @@
   const weekdaysAll = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
   const timesAll = ['6am','2pm','7pm'];
 
-  $: mapped = new Set(Object.keys($settings.labelMapping || {}).filter((k) => $settings.labelMapping[k]));
+  $: mapped = new Set(Object.keys($settings.labelMapping || {}).filter((k) => $settings.labelMapping[k]).map((k) => normalizeRuleKey(k)));
   function onlyMapped(list: string[]): string[] { return list.filter((k) => mapped.has(k)); }
   $: quick = onlyMapped(quickAll);
   $: hours = onlyMapped(hoursAll);


### PR DESCRIPTION
Add an always-visible snooze split button to trailing actions, defaulting to the shortest available snooze or guiding users to configure labels.

Previously, the snooze split button was only visible when snooze labels were configured, and it did not robustly handle non-canonical rule keys. This PR ensures the button is always present, provides clear guidance for configuration, and normalizes rule keys for consistent functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-3818ab14-cb64-4716-bde8-d977458cde22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3818ab14-cb64-4716-bde8-d977458cde22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

