### PR TITLE
Add MD3 tooltips for explanations

### DIFF
--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -376,9 +376,9 @@
   <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:0.5rem; gap:0.5rem;">
     <h3 class="m3-font-title-medium" style="margin:0">Inbox</h3>
     <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
-      <Chip variant="general" icon={iconInbox} disabled>{inboxCount}</Chip>
-      <Chip variant="general" icon={iconMarkEmailUnread} disabled>{unreadCount}</Chip>
-      <Chip variant="general" icon={iconSnooze} disabled>{soonSnoozedCount}</Chip>
+      <Chip variant="general" icon={iconInbox} disabled title="Inbox threads">{inboxCount}</Chip>
+      <Chip variant="general" icon={iconMarkEmailUnread} disabled title="Unread threads">{unreadCount}</Chip>
+      <Chip variant="general" icon={iconSnooze} disabled title="Snoozed due in 24h">{soonSnoozedCount}</Chip>
       <Button variant="text" onclick={copyDiagnostics}>{copiedDiagOk ? 'Copied!' : 'Copy diagnostics'}</Button>
       <Button variant="outlined" disabled={!nextPageToken || syncing} onclick={loadMore}>
         {#if syncing}


### PR DESCRIPTION
Add MD3-compliant explanatory tooltips to inbox counter chips using the native `title` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e568e1e-ab41-49c0-ab04-fcef26bc4538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e568e1e-ab41-49c0-ab04-fcef26bc4538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

