### PR TITLE
Request additional gmail permissions for thread view

### DIFF
--- a/svelte-app/src/lib/gmail/auth.ts
+++ b/svelte-app/src/lib/gmail/auth.ts
@@ -37,11 +37,9 @@ function loadGis(): Promise<void> {
   });
 }
 
-const SCOPES = [
+export const SCOPES = [
   'https://www.googleapis.com/auth/gmail.modify',
-  'https://www.googleapis.com/auth/gmail.readonly',
-  'https://www.googleapis.com/auth/gmail.labels',
-  'https://www.googleapis.com/auth/gmail.metadata'
+  'https://www.googleapis.com/auth/gmail.labels'
 ].join(' ');
 
 let tokenClient: google.accounts.oauth2.TokenClient | null = null;
@@ -114,7 +112,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label = 'timeout'): Pro
   });
 }
 
-export async function acquireTokenInteractive(): Promise<void> {
+export async function acquireTokenInteractive(prompt: 'none' | 'consent' | 'select_account' = 'consent'): Promise<void> {
   if (!tokenClient) throw new Error('Auth not initialized');
   const token = await withTimeout(
     new Promise<TokenResponse>((resolve, reject) => {
@@ -122,8 +120,8 @@ export async function acquireTokenInteractive(): Promise<void> {
         if ('error' in res) reject(new Error(res.error as string));
         else resolve(res as unknown as TokenResponse);
       };
-      // Use select_account to avoid forcing re-consent; GIS will still prompt if needed
-      tokenClient!.requestAccessToken({ prompt: 'select_account' });
+      // Default to 'consent' to ensure full scopes are granted on first login
+      tokenClient!.requestAccessToken({ prompt });
     }),
     30000,
     'interactive_token'

--- a/svelte-app/src/routes/+page.svelte
+++ b/svelte-app/src/routes/+page.svelte
@@ -40,7 +40,7 @@
         CLIENT_ID = CLIENT_ID || resolveGoogleClientId() as string;
         try { await initAuth(CLIENT_ID); } catch (_) {}
       }
-      await acquireTokenInteractive();
+      await acquireTokenInteractive('consent');
       hasAccount = true;
       // Navigate immediately; inbox page will hydrate
       window.location.href = `${base}/inbox`;
@@ -110,7 +110,7 @@
   <div style="display:grid; gap:1rem; max-width:28rem; margin: 10vh auto;">
     <h2 class="m3-font-headline-large" style="margin:0">Connect Gmail</h2>
     <p class="m3-font-body-medium" style="margin:0; color:rgb(var(--m3-scheme-on-surface-variant))">Sign in to your Google account to view and manage your inbox.</p>
-    <ListItem headline="Permissions" supporting="We request Gmail read/modify, labels, and metadata scopes to snooze and label threads." />
+    <ListItem headline="Permissions" supporting="We request Gmail read/modify and labels scopes to snooze and label threads." />
     <Button variant="filled" onclick={connect}>Sign in with Google</Button>
     {#if !ready}
       <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">

--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -114,7 +114,7 @@
         CLIENT_ID = CLIENT_ID || resolveGoogleClientId() as string;
         try { await initAuth(CLIENT_ID); } catch (_) {}
       }
-      await acquireTokenInteractive();
+      await acquireTokenInteractive('consent');
       await hydrate();
     } catch (e: unknown) {
       setApiError(e);

--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -10,7 +10,7 @@
   import Divider from "$lib/utils/Divider.svelte";
   import LoadingIndicator from "$lib/forms/LoadingIndicator.svelte";
   import { getMessageFull, copyGmailDiagnosticsToClipboard } from "$lib/gmail/api";
-  import { acquireTokenForScopes } from "$lib/gmail/auth";
+  import { acquireTokenForScopes, SCOPES } from "$lib/gmail/auth";
   import { aiSummarizeEmail, aiDraftReply, findUnsubscribeTarget, aiExtractUnsubscribeUrl } from "$lib/ai/providers";
   const threadId = $page.params.threadId;
   const currentThread = $derived($threads.find((t) => t.threadId === threadId));
@@ -74,11 +74,7 @@
 
   async function grantAccess(mid?: string) {
     try {
-      const scopes = [
-        'https://www.googleapis.com/auth/gmail.readonly',
-        'https://www.googleapis.com/auth/gmail.modify'
-      ].join(' ');
-      const ok = await acquireTokenForScopes(scopes, 'consent');
+      const ok = await acquireTokenForScopes(SCOPES, 'consent');
       if (ok && mid) {
         await downloadMessage(mid);
       }


### PR DESCRIPTION
Request full Gmail permissions (`gmail.modify`, `gmail.labels`) on initial authentication to prevent 403 errors when viewing message bodies.

The app previously requested `gmail.metadata` initially, which does not allow fetching full message bodies, leading to "Metadata scope doesn't allow format FULL" errors. This change ensures the necessary `gmail.modify` scope is granted upfront, allowing immediate access to message content without requiring incremental authorization.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e5fb90d-e2bd-4a62-85f9-271bacf5c20e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e5fb90d-e2bd-4a62-85f9-271bacf5c20e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

