### PR TITLE
Move copy diagnostics button to overflow

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -23,6 +23,7 @@
   import iconBackup from '@ktibow/iconset-material-symbols/backup';
   import iconRefresh from '@ktibow/iconset-material-symbols/refresh';
   import iconLogout from '@ktibow/iconset-material-symbols/logout';
+  import iconContentCopy from '@ktibow/iconset-material-symbols/content-copy';
   let { onSyncNow }: { onSyncNow?: () => void } = $props();
   let overflowDetails: HTMLDetailsElement;
   let aboutOpen = $state(false);
@@ -203,6 +204,7 @@
         <MenuItem icon={iconSettings} onclick={() => (location.href = '/settings')}>Settings</MenuItem>
         <MenuItem icon={iconBackup} onclick={async()=>{ const m = await import('$lib/db/backups'); await m.createBackup(); await m.pruneOldBackups(4); }}>Create backup</MenuItem>
         <MenuItem icon={iconRefresh} onclick={() => { const u = new URL(window.location.href); u.searchParams.set('refresh', '1'); location.href = u.toString(); }}>Force update</MenuItem>
+        <MenuItem icon={iconContentCopy} onclick={async()=>{ const ok = await copyGmailDiagnosticsToClipboard({ reason: 'topbar_manual_copy', pendingOps: $syncState.pendingOps, lastUpdatedAt: $syncState.lastUpdatedAt }); showSnackbar({ message: ok ? 'Diagnostics copied' : 'Failed to copy diagnostics', closable: true }); }}>Copy diagnostics</MenuItem>
         <MenuItem icon={iconLogout} onclick={doRelogin}>Re-login</MenuItem>
         <MenuItem icon={iconInfo} onclick={() => { aboutOpen = true; }}>About</MenuItem>
       </Menu>

--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -249,7 +249,6 @@
     <Divider inset />
 
     <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-      <Button variant="text" onclick={() => copyDiagnostics('viewer_toolbar_copy')}>Copy diagnostics</Button>
       <Button variant="text" onclick={() => relogin(currentThread.messageIds?.[0])}>Re-login</Button>
       <Button variant="text" onclick={() => archiveThread(currentThread.threadId).then(()=> showSnackbar({ message: 'Archived', actions: { Undo: () => undoLast(1) } }))}>Archive</Button>
       <Button variant="text" color="error" onclick={() => trashThread(currentThread.threadId).then(()=> showSnackbar({ message: 'Deleted', actions: { Undo: () => undoLast(1) } }))}>Delete</Button>


### PR DESCRIPTION
Move the "Copy diagnostics" button from the viewer toolbar to the top app bar's overflow menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-15d1fc84-1233-43d5-936c-12cb9dc35081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15d1fc84-1233-43d5-936c-12cb9dc35081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

