### PR TITLE
Add back button to thread view

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -23,7 +23,8 @@
   import iconBackup from '@ktibow/iconset-material-symbols/backup';
   import iconRefresh from '@ktibow/iconset-material-symbols/refresh';
   import iconLogout from '@ktibow/iconset-material-symbols/logout';
-  let { onSyncNow }: { onSyncNow?: () => void } = $props();
+  import iconBack from '@ktibow/iconset-material-symbols/chevron-left';
+  let { onSyncNow, backHref, backLabel }: { onSyncNow?: () => void; backHref?: string; backLabel?: string } = $props();
   let overflowDetails: HTMLDetailsElement;
   let aboutOpen = $state(false);
   function toggleOverflow(e: MouseEvent) {
@@ -38,6 +39,19 @@
       await syncNow();
     } catch {}
     onSyncNow && onSyncNow();
+  }
+
+  function handleBack() {
+    try {
+      const canGoBack = typeof document !== 'undefined' && document.referrer && history.length > 1;
+      if (canGoBack) {
+        history.back();
+        return;
+      }
+    } catch {}
+    if (backHref) {
+      location.href = backHref;
+    }
   }
 
   let search = $state('');
@@ -140,6 +154,11 @@
 
 <div class="topbar">
   <div class="left">
+    {#if backHref}
+      <Button variant="text" iconType="full" aria-label={backLabel || 'Back'} onclick={handleBack}>
+        <Icon icon={iconBack} />
+      </Button>
+    {/if}
     <SplitButton variant="filled" x="inner" y="down" onclick={() => doUndo(1)} on:toggle={(e) => { if (e.detail) refreshUndo(); }}>
       {#snippet children()}
         <Icon icon={iconUndo} />

--- a/svelte-app/src/routes/+layout.svelte
+++ b/svelte-app/src/routes/+layout.svelte
@@ -193,6 +193,9 @@
       snackbar.show({ message: `Failed to queue: ${e instanceof Error ? e.message : e}`, closable: true });
     }
   }
+
+  const isViewer = $derived(/\/viewer\//.test(page.url.pathname));
+  const backHref = $derived(isViewer ? (base || '') + '/inbox' : undefined);
 </script>
 
 <svelte:head>
@@ -222,7 +225,7 @@
   {/if}
   <div class="content">
     {#if normalizePath(base || "/") !== normalizePath(page.url.pathname)}
-      <TopAppBar onSyncNow={() => refreshSyncState()} />
+      <TopAppBar onSyncNow={() => refreshSyncState()} {backHref} backLabel="Back to inbox" />
       <div id="offline-banner" class="offline" class:visible={isOffline}>You are offline. Actions will be queued.</div>
     {/if}
     {@render children()}


### PR DESCRIPTION
Add a Material Design 3 back button to the TopAppBar for thread viewer pages, allowing users to return to the inbox.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9974c28-14a1-4a41-b27c-1ea40e54df67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9974c28-14a1-4a41-b27c-1ea40e54df67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

