### PR TITLE
Move copy diagnostics to overflow menu

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -24,6 +24,7 @@
   import iconRefresh from '@ktibow/iconset-material-symbols/refresh';
   import iconLogout from '@ktibow/iconset-material-symbols/logout';
   import iconBack from '@ktibow/iconset-material-symbols/chevron-left';
+  import iconCopy from '@ktibow/iconset-material-symbols/content-copy-outline';
   let { onSyncNow, backHref, backLabel }: { onSyncNow?: () => void; backHref?: string; backLabel?: string } = $props();
   let overflowDetails: HTMLDetailsElement;
   let aboutOpen = $state(false);
@@ -150,6 +151,18 @@
       showSnackbar({ message: `Re-login failed: ${e instanceof Error ? e.message : e}`, closable: true });
     }
   }
+  async function doCopyDiagnostics() {
+    try {
+      const w = typeof window !== 'undefined' ? (window as any) : undefined;
+      if (w && typeof w.__copyViewerDiagnostics === 'function') {
+        await w.__copyViewerDiagnostics();
+        showSnackbar({ message: 'Diagnostics copied', closable: true });
+        return;
+      }
+    } catch (_) {}
+    const ok = await copyGmailDiagnosticsToClipboard({ reason: 'topbar_manual_copy' });
+    showSnackbar({ message: ok ? 'Diagnostics copied' : 'Failed to copy diagnostics', closable: true });
+  }
 </script>
 
 <div class="topbar">
@@ -222,6 +235,7 @@
         <MenuItem icon={iconSettings} onclick={() => (location.href = '/settings')}>Settings</MenuItem>
         <MenuItem icon={iconBackup} onclick={async()=>{ const m = await import('$lib/db/backups'); await m.createBackup(); await m.pruneOldBackups(4); }}>Create backup</MenuItem>
         <MenuItem icon={iconRefresh} onclick={() => { const u = new URL(window.location.href); u.searchParams.set('refresh', '1'); location.href = u.toString(); }}>Force update</MenuItem>
+        <MenuItem icon={iconCopy} onclick={doCopyDiagnostics}>Copy diagnostics</MenuItem>
         <MenuItem icon={iconLogout} onclick={doRelogin}>Re-login</MenuItem>
         <MenuItem icon={iconInfo} onclick={() => { aboutOpen = true; }}>About</MenuItem>
       </Menu>

--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -164,6 +164,9 @@
       }
     } catch { alert(line); }
   }
+  if (typeof window !== 'undefined') {
+    (window as any).__copyViewerDiagnostics = async () => { await copyDiagnostics('viewer_toolbar_copy'); };
+  }
 </script>
 
 {#if currentThread}
@@ -249,7 +252,6 @@
     <Divider inset />
 
     <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-      <Button variant="text" onclick={() => copyDiagnostics('viewer_toolbar_copy')}>Copy diagnostics</Button>
       <Button variant="text" onclick={() => relogin(currentThread.messageIds?.[0])}>Re-login</Button>
       <Button variant="text" onclick={() => archiveThread(currentThread.threadId).then(()=> showSnackbar({ message: 'Archived', actions: { Undo: () => undoLast(1) } }))}>Archive</Button>
       <Button variant="text" color="error" onclick={() => trashThread(currentThread.threadId).then(()=> showSnackbar({ message: 'Deleted', actions: { Undo: () => undoLast(1) } }))}>Delete</Button>


### PR DESCRIPTION
Move the "Copy diagnostics" button from the viewer toolbar to the top app bar's overflow menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6fbba2c-1651-4cac-823c-9b88ede8d16a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6fbba2c-1651-4cac-823c-9b88ede8d16a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

