### PR TITLE
Update snooze buttons to MD3 standards

### DIFF
--- a/svelte-app/src/lib/utils/ThreadListRow.svelte
+++ b/svelte-app/src/lib/utils/ThreadListRow.svelte
@@ -222,7 +222,7 @@
             <Menu>
               {#if mappedKeys.length > 0}
                 <div class="list">
-                  {#each ['1h','2h','3h','2p','6a','7p','2d','4d','mon','fri','7d','14d','30d'] as item}
+                  {#each ['2p','6a','7p','2d','4d','mon','fri','7 day','14 day','30 days','1h','2h','3h'] as item}
                     {#if isMapped(toRuleKey(item))}
                       <Button variant="text" onclick={() => trySnooze(toRuleKey(item))}>{item}</Button>
                     {/if}


### PR DESCRIPTION
Update snooze dropdown options to a new MD3-compliant list.

---
<a href="https://cursor.com/background-agent?bcId=bc-732b6546-3b16-43d6-94aa-73d8323afeb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-732b6546-3b16-43d6-94aa-73d8323afeb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

