### PR TITLE
Debug edge force update failure

### DIFF
--- a/svelte-app/src/app.html
+++ b/svelte-app/src/app.html
@@ -21,7 +21,7 @@
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
           navigator.serviceWorker
-            .register('%sveltekit.assets%/sw.js')
+            .register('/sw.js')
             .catch(() => {
               /* noop */
             });


### PR DESCRIPTION
Harden service worker force update logic and add diagnostics to resolve update failures on Edge.

Edge was observed to serve a stale `index.html` from its cache during navigation, preventing the app from updating after a force refresh. This PR ensures navigation requests bypass the service worker cache, standardizes service worker registration, and enhances the force update flow with cache-busting and detailed console/clipboard diagnostics to aid future debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-3123cb49-34f2-4d73-8943-2e6673c58618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3123cb49-34f2-4d73-8943-2e6673c58618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

