### PR TITLE
Add MD3 font size setting

### DIFF
--- a/svelte-app/src/app.css
+++ b/svelte-app/src/app.css
@@ -1,6 +1,10 @@
 @import url("$lib/misc/styles.css");
 @import url("$lib/misc/recommended-styles.css");
 
+html {
+  font-size: var(--m3-font-scale, 100%);
+}
+
 body {
   margin: 0;
   background-color: rgb(var(--m3-scheme-background));

--- a/svelte-app/src/lib/stores/settings.ts
+++ b/svelte-app/src/lib/stores/settings.ts
@@ -29,6 +29,8 @@ export type AppSettings = {
   swipeDisappearMs?: number;
   /** Sorting preference for inbox thread list */
   inboxSort?: 'date_desc' | 'date_asc' | 'unread_first' | 'sender_az' | 'sender_za' | 'subject_az' | 'subject_za';
+  /** Global font scale percent for rem-based MD3 typography (100 = default) */
+  fontScalePercent?: number;
 };
 
 const DEFAULTS: AppSettings = {
@@ -44,7 +46,8 @@ const DEFAULTS: AppSettings = {
   confirmDelete: false,
   swipeCommitVelocityPxPerSec: 1000,
   swipeDisappearMs: 5000,
-  inboxSort: 'date_desc'
+  inboxSort: 'date_desc',
+  fontScalePercent: 100
 };
 
 export const settings = writable<AppSettings>({ ...DEFAULTS });

--- a/svelte-app/src/routes/+layout.svelte
+++ b/svelte-app/src/routes/+layout.svelte
@@ -33,6 +33,7 @@
   import { copyGmailDiagnosticsToClipboard } from "$lib/gmail/api";
   import { startUpdateChecker } from "$lib/update/checker";
   import KeyboardShortcutsDialog from "$lib/misc/KeyboardShortcutsDialog.svelte";
+  import { settings as appSettings } from "$lib/stores/settings";
   
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
 
@@ -260,7 +261,16 @@
   let preAuthDialog: ReturnType<typeof PreAuthDialog>;
   let isOffline = $state(false);
   let kbdDialog: ReturnType<typeof KeyboardShortcutsDialog>;
-
+  
+  $effect(() => {
+    const percent = (typeof ($appSettings as any)?.fontScalePercent === 'number' ? ($appSettings as any).fontScalePercent : 100);
+    try {
+      if (typeof document !== 'undefined') {
+        document.documentElement.style.setProperty('--m3-font-scale', `${percent}%`);
+      }
+    } catch {}
+  });
+  
   $effect(() => { if (snackbar) registerSnackbar(snackbar.show); });
   $effect(() => { if (preAuthDialog) registerPreAuth(preAuthDialog.show); });
 

--- a/svelte-app/src/routes/settings/+page.svelte
+++ b/svelte-app/src/routes/settings/+page.svelte
@@ -50,6 +50,7 @@
   const timeKeys = ['6am','2pm','7pm'];
   const persistentKeys = ['Desktop','long-term'];
   const ruleKeys = [ ...new Set([ ...quickKeys, ...hourKeys, ...dayKeys, ...weekdayKeys, ...timeKeys, ...persistentKeys ]) ];
+  let _fontScalePercent = $state(100);
 
   // Tabs
   let currentTab = $state<'app' | 'mapping' | 'backups'>('app');
@@ -80,6 +81,7 @@
     _swipeDisappearMs = Number(s.swipeDisappearMs || 5000);
     mappingJson = JSON.stringify(s.labelMapping, null, 2);
     uiMapping = { ...s.labelMapping };
+    _fontScalePercent = Number((s as any).fontScalePercent || 100);
 
     const db = await getDB();
     const tx = db.transaction('labels');
@@ -114,7 +116,7 @@
         Number(_swipeCommitVelocityPxPerSec || 1000) !== Number(s.swipeCommitVelocityPxPerSec || 1000) ||
         Number(_swipeDisappearMs || 5000) !== Number(s.swipeDisappearMs || 800)
       );
-      return mappingChanged || uiMappingChanged || appChanged;
+      return mappingChanged || uiMappingChanged || appChanged || (Number(_fontScalePercent || 100) !== Number((s as any).fontScalePercent || 100));
     } catch { return false; }
   });
 
@@ -238,7 +240,7 @@
   }
 
   async function saveAppSettings() {
-    await updateAppSettings({ anchorHour: _anchorHour, roundMinutes: _roundMinutes, unreadOnUnsnooze: _unreadOnUnsnooze, notifEnabled: _notifEnabled, aiProvider: _aiProvider, aiApiKey: _aiApiKey, aiModel: _aiModel, aiPageFetchOptIn: _aiPageFetchOptIn, taskFilePath: _taskFilePath, trailingRefreshDelayMs: Math.max(0, Number(_trailingRefreshDelayMs || 0)), trailingSlideOutDurationMs: Math.max(0, Number(_trailingSlideOutDurationMs || 0)), swipeRightPrimary: _swipeRightPrimary, swipeLeftPrimary: _swipeLeftPrimary, confirmDelete: _confirmDelete, swipeCommitVelocityPxPerSec: Math.max(100, Number(_swipeCommitVelocityPxPerSec || 1000)), swipeDisappearMs: Math.max(100, Number(_swipeDisappearMs || 800)) });
+    await updateAppSettings({ anchorHour: _anchorHour, roundMinutes: _roundMinutes, unreadOnUnsnooze: _unreadOnUnsnooze, notifEnabled: _notifEnabled, aiProvider: _aiProvider, aiApiKey: _aiApiKey, aiModel: _aiModel, aiPageFetchOptIn: _aiPageFetchOptIn, taskFilePath: _taskFilePath, trailingRefreshDelayMs: Math.max(0, Number(_trailingRefreshDelayMs || 0)), trailingSlideOutDurationMs: Math.max(0, Number(_trailingSlideOutDurationMs || 0)), swipeRightPrimary: _swipeRightPrimary, swipeLeftPrimary: _swipeLeftPrimary, confirmDelete: _confirmDelete, swipeCommitVelocityPxPerSec: Math.max(100, Number(_swipeCommitVelocityPxPerSec || 1000)), swipeDisappearMs: Math.max(100, Number(_swipeDisappearMs || 800)), fontScalePercent: Math.max(50, Math.min(200, Number(_fontScalePercent || 100))) });
     if (_notifEnabled && 'Notification' in window) {
       const p = await Notification.requestPermission();
       if (p !== 'granted') {
@@ -295,6 +297,11 @@
       <TextFieldOutlined label="Round minutes (1-60)" type="number" min="1" max="60" step="1" bind:value={(_roundMinutes as any)} />
       <TextFieldOutlined label="Trailing refresh delay (ms)" type="number" min="0" step="100" bind:value={(_trailingRefreshDelayMs as any)} />
       <TextFieldOutlined label="Slide-out duration on refresh (ms)" type="number" min="0" step="20" bind:value={(_trailingSlideOutDurationMs as any)} />
+      <div style="display:flex; gap:0.5rem; align-items:center;">
+        <TextFieldOutlined label="Font size (%)" type="number" min="50" max="200" step="1" bind:value={(_fontScalePercent as any)} />
+        <Button variant="outlined" onclick={() => (_fontScalePercent = Math.max(50, Math.min(200, Number(_fontScalePercent || 0) - 1)))}>-1%</Button>
+        <Button variant="outlined" onclick={() => (_fontScalePercent = Math.max(50, Math.min(200, Number(_fontScalePercent || 0) + 1)))}>+1%</Button>
+      </div>
       <label style="display:flex; align-items:center; gap:0.5rem;">
         <Checkbox>
           <input type="checkbox" bind:checked={_unreadOnUnsnooze} />


### PR DESCRIPTION
Add a global font size setting to app settings for consistent MD3 typography scaling.

This introduces a `fontScalePercent` setting, applied globally via a CSS variable (`--m3-font-scale`) on the `html` element. This ensures all Material 3 rem-based typography scales consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6271b2a-0bb4-43cc-8852-294d13a40750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6271b2a-0bb4-43cc-8852-294d13a40750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

