### PR TITLE
Adjust thread view for screen size

### DIFF
--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -511,5 +511,19 @@ function scrollToBottom() {
     max-width: 100% !important;
     height: auto !important;
   }
+  /* Mobile: avoid clipping wide email layouts; prefer container scroll to hidden overflow */
+  .html-body {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* Override inline min-widths commonly set by marketing emails */
+  :global(.html-body [style*="min-width"]) {
+    min-width: 0 !important;
+  }
+  /* Ensure attribute-sized tables scale down */
+  :global(.html-body table[width]) {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
 </style>
 


### PR DESCRIPTION
Adjust thread view to prevent horizontal clipping on mobile by enabling horizontal scrolling and overriding fixed widths.

---
<a href="https://cursor.com/background-agent?bcId=bc-927b0629-bac7-4a35-bd04-9250c8947e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-927b0629-bac7-4a35-bd04-9250c8947e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

