### PR TITLE
Sync inbox emails with Gmail

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -50,6 +50,11 @@
         const { clearAllHolds } = await import('$lib/stores/holds');
         clearAllHolds();
       } catch {}
+      // Ensure we don't show stale threads after server sync
+      try {
+        const mod = await import('../../routes/inbox/+page.svelte');
+        if (typeof (mod as any).resetInboxCache === 'function') await (mod as any).resetInboxCache();
+      } catch {}
       try {
         const mod = await import('../../routes/inbox/+page.svelte');
         if (typeof (mod as any).reloadFromCache === 'function') await (mod as any).reloadFromCache();

--- a/svelte-app/src/routes/api/openai/+server.ts
+++ b/svelte-app/src/routes/api/openai/+server.ts
@@ -1,10 +1,11 @@
 export const prerender = false;
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { OPENAI_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 export const POST: RequestHandler = async ({ request }) => {
-  if (!OPENAI_API_KEY) {
+  const apiKey = env.OPENAI_API_KEY;
+  if (!apiKey) {
     return new Response(JSON.stringify({ error: 'OPENAI_API_KEY not set' }), { status: 500 });
   }
 
@@ -16,7 +17,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const r = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({ model, messages, temperature })

--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -306,6 +306,14 @@
     }
   }
 
+  export async function resetInboxCache() {
+    const db = await getDB();
+    try { await db.clear('threads'); } catch {}
+    try { await db.clear('messages'); } catch {}
+    threadsStore.set([]);
+    messagesStore.set({});
+  }
+
   onMount(() => {
     const unsub = authState.subscribe((s) => (ready = s.ready));
     if (($threadsStore || []).length) loading = false;
@@ -347,6 +355,8 @@
       try {
         showSnackbar({ message: 'Refreshing inbox…' });
         syncing = true;
+        // Clear stale local cache before fetching fresh data
+        try { await resetInboxCache(); } catch {}
         await hydrate();
         showSnackbar({ message: 'Inbox up to date', timeout: 3000 });
       } catch (e) {


### PR DESCRIPTION
Clear local inbox cache before refresh to prevent stale emails from appearing and fix OpenAI API key build issue.

The user reported that emails no longer in their Gmail inbox were still visible in the application after a refresh. This was due to stale data persisting in the local cache. This PR introduces a mechanism to clear the local `threads` and `messages` cache before fetching new data, ensuring the inbox accurately reflects the current state from Gmail. Additionally, a build error related to the OpenAI API key environment variable was resolved by switching to dynamic environment access.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcf6c4dc-5b9f-49b4-854b-b7bd616deb79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcf6c4dc-5b9f-49b4-854b-b7bd616deb79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

