### PR TITLE
Adjust email counter display and badge positioning

### DIFF
--- a/svelte-app/src/lib/misc/TopAppBar.svelte
+++ b/svelte-app/src/lib/misc/TopAppBar.svelte
@@ -14,6 +14,7 @@
   import { appVersion, buildId } from '$lib/utils/version';
   import { checkForUpdateOnce, hardReloadNow } from '$lib/update/checker';
   import { signOut, acquireTokenInteractive, resolveGoogleClientId, initAuth } from '$lib/gmail/auth';
+  import { threads as threadsStore } from '$lib/stores/threads';
   import iconSearch from '@ktibow/iconset-material-symbols/search';
   import iconMore from '@ktibow/iconset-material-symbols/more-vert';
   import iconInfo from '@ktibow/iconset-material-symbols/info';
@@ -26,6 +27,8 @@
   import iconLogout from '@ktibow/iconset-material-symbols/logout';
   import iconBack from '@ktibow/iconset-material-symbols/chevron-left';
   import iconCopy from '@ktibow/iconset-material-symbols/content-copy-outline';
+  import iconInbox from '@ktibow/iconset-material-symbols/inbox';
+  import iconMarkEmailUnread from '@ktibow/iconset-material-symbols/mark-email-unread';
   import { onMount } from 'svelte';
   let { onSyncNow, backHref, backLabel }: { onSyncNow?: () => void; backHref?: string; backLabel?: string } = $props();
   let overflowDetails: HTMLDetailsElement;
@@ -264,6 +267,11 @@
       console.error(e);
     }
   });
+
+  // Inbox counters (local view based on cached threads)
+  const inboxThreads = $derived(($threadsStore || []).filter((t) => (t.labelIds || []).includes('INBOX')));
+  const inboxCount = $derived(inboxThreads.length);
+  const unreadCount = $derived(inboxThreads.filter((t) => (t.labelIds || []).includes('UNREAD')).length);
 </script>
 
 <div class="topbar">
@@ -335,6 +343,11 @@
         </div>
       {/snippet}
     </SplitButton>
+
+    <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
+      <Chip variant="general" icon={iconInbox} disabled title="Inbox threads" onclick={() => {}}>{inboxCount}</Chip>
+      <Chip variant="general" icon={iconMarkEmailUnread} disabled title="Unread threads" onclick={() => {}}>{unreadCount}</Chip>
+    </div>
 
     <details class="overflow" bind:this={overflowDetails}>
       <summary aria-label="More actions" class="summary-btn" onclick={toggleOverflow}>

--- a/svelte-app/src/routes/inbox/+page.svelte
+++ b/svelte-app/src/routes/inbox/+page.svelte
@@ -10,16 +10,14 @@
   import Button from '$lib/buttons/Button.svelte';
   import Card from '$lib/containers/Card.svelte';
   import LoadingIndicator from '$lib/forms/LoadingIndicator.svelte';
-  import Chip from '$lib/forms/Chip.svelte';
+  
   import Checkbox from '$lib/forms/Checkbox.svelte';
-  import { snoozeByThread } from '$lib/stores/snooze';
+  
   import { archiveThread, trashThread, undoLast } from '$lib/queue/intents';
   import { snoozeThreadByRule } from '$lib/snooze/actions';
   import { settings, updateAppSettings } from '$lib/stores/settings';
   import { show as showSnackbar } from '$lib/containers/snackbar';
-  import iconInbox from '@ktibow/iconset-material-symbols/inbox';
-  import iconMarkEmailUnread from '@ktibow/iconset-material-symbols/mark-email-unread';
-  import iconSnooze from '@ktibow/iconset-material-symbols/snooze';
+  
   import { getLabel } from '$lib/gmail/api';
   import { trailingHolds } from '$lib/stores/holds';
   import Menu from '$lib/containers/Menu.svelte';
@@ -241,24 +239,7 @@
   }
   const totalThreadsCount = $derived($threadsStore?.length || 0);
   let inboxLabelStats = $state<{ messagesTotal?: number; messagesUnread?: number; threadsTotal?: number; threadsUnread?: number } | null>(null);
-  const inboxCount = $derived(inboxLabelStats?.threadsTotal ?? inboxThreads.length);
   const visibleThreadsCount = $derived(filteredThreads?.length || 0);
-  const unreadCount = $derived(inboxLabelStats?.threadsUnread ?? inboxThreads.filter((t) => (t.labelIds || []).includes('UNREAD')).length);
-  const soonSnoozedCount = $derived(
-    (() => {
-      try {
-        const cutoff = Date.now() + 24 * 60 * 60 * 1000;
-        const map = $snoozeByThread || {};
-        let count = 0;
-        for (const info of Object.values(map)) {
-          if (info && typeof info.dueAtUtc === 'number' && info.dueAtUtc <= cutoff) count++;
-        }
-        return count;
-      } catch {
-        return 0;
-      }
-    })()
-  );
   $effect(() => {
     // Log UI-level diagnostics in dev builds only
     try {
@@ -678,9 +659,7 @@
   <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:0.5rem; gap:0.5rem;">
     <h3 class="m3-font-title-medium" style="margin:0">Inbox</h3>
     <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
-      <Chip variant="general" icon={iconInbox} disabled title="Inbox threads" onclick={() => {}}>{inboxCount}</Chip>
-      <Chip variant="general" icon={iconMarkEmailUnread} disabled title="Unread threads" onclick={() => {}}>{unreadCount}</Chip>
-      <Chip variant="general" icon={iconSnooze} disabled title="Snoozed due in 24h" onclick={() => {}}>{soonSnoozedCount}</Chip>
+      
       <details class="sort">
         <summary class="summary-btn">
           <Button variant="text">


### PR DESCRIPTION
Remove the snoozed email counter and move the Inbox and Unread counters to the top app bar after the redo split buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-720ca790-31a0-4dd7-9768-c72be31e778f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-720ca790-31a0-4dd7-9768-c72be31e778f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

