### PR TITLE
Replace Google GIS login modal with snackbar

### DIFF
--- a/svelte-app/src/routes/+layout.svelte
+++ b/svelte-app/src/routes/+layout.svelte
@@ -22,8 +22,7 @@
   import FAB from "$lib/buttons/FAB.svelte";
   import Snackbar from "$lib/containers/Snackbar.svelte";
   import { register as registerSnackbar, show as showSnackbar } from "$lib/containers/snackbar";
-  import PreAuthDialog from "$lib/gmail/PreAuthDialog.svelte";
-  import { registerPreAuth } from "$lib/gmail/preauth";
+  
   import iconCompose from "@ktibow/iconset-material-symbols/edit";
   import BottomSheet from "$lib/containers/BottomSheet.svelte";
   import TextField from "$lib/forms/TextField.svelte";
@@ -284,8 +283,7 @@
   let subject = $state("");
   let body = $state("");
   let snackbar: ReturnType<typeof Snackbar>;
-  let preAuthDialog: ReturnType<typeof PreAuthDialog>;
-  let isOffline = $state(false);
+    let isOffline = $state(false);
   let kbdDialog: ReturnType<typeof KeyboardShortcutsDialog>;
   
   $effect(() => {
@@ -298,7 +296,6 @@
   });
   
   $effect(() => { if (snackbar) registerSnackbar(snackbar.show); });
-  $effect(() => { if (preAuthDialog) registerPreAuth(preAuthDialog.show); });
 
   function makeRfc2822(): string {
     const boundary = `----Jmail-${Math.random().toString(36).slice(2)}`;
@@ -370,7 +367,6 @@
       </div>
     {/if}
     <Snackbar bind:this={snackbar} />
-    <PreAuthDialog bind:this={preAuthDialog} />
     <KeyboardShortcutsDialog bind:this={kbdDialog} />
   </div>
 </div>


### PR DESCRIPTION
Replace the blocking Google pre-authentication modal dialog with a non-blocking snackbar to remove a mandatory user interaction before Google GIS login.

---
<a href="https://cursor.com/background-agent?bcId=bc-df71fc5b-f57c-4b99-97ad-4e8548b4986a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df71fc5b-f57c-4b99-97ad-4e8548b4986a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

