### PR TITLE
Replace alerts with snackbars for notifications

### DIFF
--- a/svelte-app/src/lib/gmail/api.ts
+++ b/svelte-app/src/lib/gmail/api.ts
@@ -85,13 +85,15 @@ export async function copyGmailDiagnosticsToClipboard(extra?: Record<string, unk
       }
     }
     
-    // Fallback 2: Show in alert for manual copy (last resort)
+    // Fallback 2: Surface via snackbar/log for manual copy (last resort)
     try {
-      alert('Diagnostics (copy manually):\n\n' + text);
-      return false; // Not technically copied to clipboard
-    } catch (alertError) {
-      console.warn('[GmailAPI] Alert fallback failed:', alertError);
+      const { show } = await import('$lib/containers/snackbar');
+      show({ message: 'Clipboard access blocked. Open console to copy diagnostics.', timeout: 6000, closable: true });
+    } catch (_) {
+      // If snackbar import fails (non-UI context), proceed silently
     }
+    try { console.log('[GmailAPI] Diagnostics (manual copy)', text); } catch (_) {}
+    return false; // Not technically copied to clipboard
     
   } catch (error) {
     console.error('[GmailAPI] copyGmailDiagnosticsToClipboard failed:', error);

--- a/svelte-app/src/routes/+page.svelte
+++ b/svelte-app/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import { initAuth, acquireTokenInteractive, authState, getAuthDiagnostics, resolveGoogleClientId } from '$lib/gmail/auth';
   import { getDB } from '$lib/db/indexeddb';
   import { copyGmailDiagnosticsToClipboard } from '$lib/gmail/api';
+  import { show as showSnackbar } from '$lib/containers/snackbar';
   
 
   let CLIENT_ID = $state(import.meta.env.VITE_GOOGLE_CLIENT_ID as string);
@@ -133,34 +134,9 @@
       
       // Provide user feedback
       if (copiedDiagOk) {
-        // Show success message
-        if (typeof window !== 'undefined' && 'showSnackbar' in window) {
-          try {
-            const { show } = await import('$lib/containers/snackbar');
-            show({ message: 'Diagnostics copied to clipboard', timeout: 3000 });
-          } catch (_) {
-            // Fallback if snackbar not available
-            alert('Diagnostics copied to clipboard successfully!');
-          }
-        } else {
-          alert('Diagnostics copied to clipboard successfully!');
-        }
+        showSnackbar({ message: 'Diagnostics copied to clipboard', timeout: 3000 });
       } else {
-        // Show fallback message
-        if (typeof window !== 'undefined' && 'showSnackbar' in window) {
-          try {
-            const { show } = await import('$lib/containers/snackbar');
-            show({ 
-              message: 'Clipboard access denied. Check console for diagnostics.', 
-              timeout: 5000 
-            });
-          } catch (_) {
-            alert('Clipboard access denied. Check browser console for diagnostics.');
-          }
-        } else {
-          alert('Clipboard access denied. Check browser console for diagnostics.');
-        }
-        
+        showSnackbar({ message: 'Clipboard access denied. Check console for diagnostics.', timeout: 5000, closable: true });
         // Also log to console as fallback
         console.log('Diagnostics (console fallback):', payload);
       }
@@ -169,19 +145,7 @@
       copiedDiagOk = false;
       
       // Show error message
-      if (typeof window !== 'undefined' && 'showSnackbar' in window) {
-        try {
-          const { show } = await import('$lib/containers/snackbar');
-          show({ 
-            message: 'Failed to copy diagnostics. Check console for error.', 
-            timeout: 5000 
-          });
-        } catch (_) {
-          alert('Failed to copy diagnostics. Check browser console for error.');
-        }
-      } else {
-        alert('Failed to copy diagnostics. Check browser console for error.');
-      }
+      showSnackbar({ message: 'Failed to copy diagnostics. Check console for error.', timeout: 5000, closable: true });
     } finally {
       copyingDiagnostics = false;
     }
@@ -243,7 +207,7 @@
         } catch (_) { ok = false; }
       }
       if (!ok) {
-        try { alert('Runtime checks:\n\n' + text); } catch (_) {}
+        showSnackbar({ message: 'Clipboard unavailable. Runtime checks printed to console.', timeout: 6000, closable: true });
       }
       copiedRuntimeOk = ok;
       // Also log to console for easy inspection

--- a/svelte-app/src/routes/viewer/[threadId]/+page.svelte
+++ b/svelte-app/src/routes/viewer/[threadId]/+page.svelte
@@ -628,19 +628,19 @@
       try {
         const readBack = await navigator.clipboard.readText();
         if (readBack === line) {
-          alert('Task line copied to clipboard.');
+          showSnackbar({ message: 'Task line copied to clipboard.', closable: true });
         } else {
-          alert(line);
+          showSnackbar({ message: line, closable: true });
         }
       } catch (_) {
         // If we cannot read the clipboard (permission), show the line for manual copy
-        alert(line);
+        showSnackbar({ message: line, closable: true });
       }
-    } catch { alert(line); }
+    } catch { showSnackbar({ message: line, closable: true }); }
   }
   async function loadForEdit(filter: ThreadFilter) {
-    // This function is not yet implemented in FilterBar, so we'll just alert for now
-    alert(`Load filter "${filter.name}" for editing.`);
+    // This function is not yet implemented in FilterBar, so surface via snackbar for now
+    showSnackbar({ message: `Load filter "${filter.name}" for editing.`, closable: true });
     // In a real app, you'd set the filter's state in FilterBar
   }
   async function onDeleteSavedFilter(id: string) {


### PR DESCRIPTION
Replace browser `alert()` calls with snackbar notifications to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-36926af2-9655-4cca-ad45-cebad55e04d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36926af2-9655-4cca-ad45-cebad55e04d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

