### PR TITLE
Enhance google authentication with persistent tokens and multi-client support

### DIFF
--- a/api/_lib/crypto.js
+++ b/api/_lib/crypto.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const crypto = require("crypto");
+
+// Helpers: base64url without padding
+function base64urlEncode(buf) {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function base64urlDecode(str) {
+  const pad = 4 - (str.length % 4 || 4);
+  const b64 = (str + "===").slice(0, str.length + pad).replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(b64, "base64");
+}
+
+function getKeyFromEnv() {
+  const secret = process.env.COOKIE_SECRET || process.env.SESSION_SECRET || "dev_secret_change_me";
+  // Derive 32-byte key using SHA-256 of provided secret
+  return crypto.createHash("sha256").update(String(secret)).digest();
+}
+
+function encryptJson(data) {
+  const key = getKeyFromEnv();
+  const iv = crypto.randomBytes(12); // GCM nonce
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const plaintext = Buffer.from(JSON.stringify(data), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [base64urlEncode(iv), base64urlEncode(ciphertext), base64urlEncode(tag)].join(".");
+}
+
+function decryptJson(token) {
+  try {
+    const [ivB64, ctB64, tagB64] = String(token).split(".");
+    if (!ivB64 || !ctB64 || !tagB64) return null;
+    const key = getKeyFromEnv();
+    const iv = base64urlDecode(ivB64);
+    const ciphertext = base64urlDecode(ctB64);
+    const tag = base64urlDecode(tagB64);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return JSON.parse(plaintext.toString("utf8"));
+  } catch (_) {
+    return null;
+  }
+}
+
+function sign(data) {
+  const key = process.env.COOKIE_SIGNING_SECRET || process.env.COOKIE_SECRET || "dev_secret_change_me";
+  return base64urlEncode(crypto.createHmac("sha256", String(key)).update(data).digest());
+}
+
+function randomId(bytes = 16) {
+  return base64urlEncode(crypto.randomBytes(bytes));
+}
+
+function sha256Base64url(input) {
+  return base64urlEncode(crypto.createHash("sha256").update(input).digest());
+}
+
+module.exports = {
+  base64urlEncode,
+  base64urlDecode,
+  encryptJson,
+  decryptJson,
+  sign,
+  randomId,
+  sha256Base64url
+};
+

--- a/api/_lib/session.js
+++ b/api/_lib/session.js
@@ -1,0 +1,192 @@
+"use strict";
+
+const { encryptJson, decryptJson, sign, randomId } = require("./crypto");
+
+const COOKIE_NAME_RT = "g_rt";
+const COOKIE_NAME_SESS = "g_sess";
+const COOKIE_NAME_PKCE = "g_pkce";
+const COOKIE_NAME_STATE = "g_state";
+
+function isSecureCookies() {
+  const v = process.env.COOKIE_SECURE;
+  if (typeof v === "string" && v.length) return v === "1" || v.toLowerCase() === "true";
+  return true; // default secure
+}
+
+function cookieSerialize(name, value, options = {}) {
+  const parts = [name + "=" + value];
+  if (options.maxAge) parts.push("Max-Age=" + Math.floor(options.maxAge));
+  if (options.expires) parts.push("Expires=" + options.expires.toUTCString());
+  parts.push("Path=" + (options.path || "/"));
+  if (options.domain) parts.push("Domain=" + options.domain);
+  if (options.sameSite) parts.push("SameSite=" + options.sameSite);
+  if (options.httpOnly) parts.push("HttpOnly");
+  if (options.secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+function parseCookies(req) {
+  const header = req.headers["cookie"]; 
+  if (!header) return {};
+  const out = {};
+  String(header).split(";").forEach((p) => {
+    const i = p.indexOf("=");
+    if (i === -1) return;
+    const k = p.slice(0, i).trim();
+    const v = p.slice(i + 1).trim();
+    out[k] = v;
+  });
+  return out;
+}
+
+function setRefreshCookie(headers, payload) {
+  const months6 = 60 * 60 * 24 * 30 * 6;
+  const serialized = encryptJson(payload);
+  headers.push(
+    cookieSerialize(COOKIE_NAME_RT, serialized, {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      maxAge: months6
+    })
+  );
+}
+
+function clearRefreshCookie(headers) {
+  headers.push(
+    cookieSerialize(COOKIE_NAME_RT, "", {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      expires: new Date(0)
+    })
+  );
+}
+
+function setSessionCookie(headers, session) {
+  const hours1 = 60 * 60; 
+  const payload = JSON.stringify(session);
+  const sig = sign(payload);
+  const value = Buffer.from(payload, "utf8").toString("base64") + "." + sig;
+  headers.push(
+    cookieSerialize(COOKIE_NAME_SESS, value, {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      maxAge: hours1
+    })
+  );
+}
+
+function clearSessionCookie(headers) {
+  headers.push(
+    cookieSerialize(COOKIE_NAME_SESS, "", {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      expires: new Date(0)
+    })
+  );
+}
+
+function getSession(req) {
+  const cookies = parseCookies(req);
+  const v = cookies[COOKIE_NAME_SESS];
+  if (!v) return null;
+  const dot = v.lastIndexOf(".");
+  if (dot === -1) return null;
+  const payloadB64 = v.slice(0, dot);
+  const sig = v.slice(dot + 1);
+  const payload = Buffer.from(payloadB64, "base64").toString("utf8");
+  if (sign(payload) !== sig) return null;
+  try {
+    const session = JSON.parse(payload);
+    if (typeof session.exp === "number" && Date.now() / 1000 > session.exp) return null;
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+function getRefreshPayload(req) {
+  const cookies = parseCookies(req);
+  const enc = cookies[COOKIE_NAME_RT];
+  if (!enc) return null;
+  return decryptJson(enc);
+}
+
+function setPkceCookie(headers, verifier) {
+  headers.push(
+    cookieSerialize(COOKIE_NAME_PKCE, verifier, {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      maxAge: 300
+    })
+  );
+}
+
+function popPkceVerifier(req, headers) {
+  const cookies = parseCookies(req);
+  const v = cookies[COOKIE_NAME_PKCE];
+  headers.push(
+    cookieSerialize(COOKIE_NAME_PKCE, "", {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      expires: new Date(0)
+    })
+  );
+  return v || null;
+}
+
+function setStateCookie(headers, state) {
+  headers.push(
+    cookieSerialize(COOKIE_NAME_STATE, state, {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      maxAge: 600
+    })
+  );
+}
+
+function popStateCookie(req, headers) {
+  const cookies = parseCookies(req);
+  const v = cookies[COOKIE_NAME_STATE];
+  headers.push(
+    cookieSerialize(COOKIE_NAME_STATE, "", {
+      httpOnly: true,
+      secure: isSecureCookies(),
+      sameSite: "Lax",
+      path: "/",
+      expires: new Date(0)
+    })
+  );
+  return v || null;
+}
+
+module.exports = {
+  COOKIE_NAME_RT,
+  COOKIE_NAME_SESS,
+  parseCookies,
+  setRefreshCookie,
+  clearRefreshCookie,
+  setSessionCookie,
+  clearSessionCookie,
+  getSession,
+  getRefreshPayload,
+  setPkceCookie,
+  popPkceVerifier,
+  setStateCookie,
+  popStateCookie,
+  randomId
+};
+

--- a/api/gmail-proxy/function.json
+++ b/api/gmail-proxy/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post", "patch", "delete"],
+      "route": "gmail/{*segments}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/gmail-proxy/index.js
+++ b/api/gmail-proxy/index.js
@@ -1,0 +1,75 @@
+const fetch = global.fetch;
+const { getSession, getRefreshPayload, setSessionCookie, setRefreshCookie } = require("../_lib/session");
+
+async function getGoogleAccessToken(payload) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) throw new Error("Missing GOOGLE_* envs");
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: payload.refresh_token
+  });
+  const r = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params
+  });
+  if (!r.ok) {
+    const t = await r.text();
+    throw new Error("refresh_failed:" + t.slice(0, 256));
+  }
+  return await r.json();
+}
+
+module.exports = async function (context, req) {
+  const method = (req.method || "GET").toUpperCase();
+  const rawPath = req.params && req.params["*" ] ? String(req.params["*"]) : "";
+  const path = rawPath.replace(/^\/+/, "");
+  const resHeaders = [];
+
+  const session = getSession(req);
+  const payload = getRefreshPayload(req);
+  if (!session || !payload || !payload.refresh_token) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "unauthenticated" }) };
+    return;
+  }
+
+  // Obtain a fresh Google access token
+  let token;
+  try {
+    const tok = await getGoogleAccessToken(payload);
+    token = tok.access_token;
+    // rotate session cookie TTL
+    const now = Math.floor(Date.now() / 1000);
+    setSessionCookie(resHeaders, { sub: session.sub, email: session.email, scope: session.scope || tok.scope, iat: now, exp: now + 3600 });
+    if (tok.refresh_token && tok.refresh_token !== payload.refresh_token) {
+      setRefreshCookie(resHeaders, { refresh_token: tok.refresh_token, sub: session.sub, email: session.email, scope: tok.scope || session.scope });
+    }
+  } catch (e) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "token_refresh_failed" }) };
+    return;
+  }
+
+  const base = "https://gmail.googleapis.com/gmail/v1/users/me";
+  const url = `${base}/${path}`.replace(/\/$/, "");
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json"
+  };
+  const init = { method, headers };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = typeof req.body === "string" ? req.body : JSON.stringify(req.body || {});
+  }
+  const r = await fetch(url, init);
+  const text = await r.text();
+  const forward = ["content-type"]; // safe subset
+  const hdr = { "Set-Cookie": resHeaders };
+  for (const h of forward) {
+    const v = r.headers.get(h);
+    if (v) hdr[h] = v;
+  }
+  context.res = { status: r.status, headers: hdr, body: text };
+};
+

--- a/api/google-callback/function.json
+++ b/api/google-callback/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "google/callback"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-callback/index.js
+++ b/api/google-callback/index.js
@@ -1,0 +1,88 @@
+const fetch = global.fetch;
+const { popPkceVerifier, popStateCookie, setRefreshCookie, setSessionCookie } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "GET") {
+    context.res = { status: 405, headers: { "Allow": "GET" }, body: "" };
+    return;
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const redirectUri = (process.env.APP_BASE_URL || "") + "/api/google/callback";
+  if (!clientId || !clientSecret || !redirectUri) {
+    context.res = { status: 500, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "Missing GOOGLE_* envs or APP_BASE_URL" }) };
+    return;
+  }
+
+  const cookies = [];
+  const expectedStateCookie = popStateCookie(req, cookies) || "";
+  const pkceVerifier = popPkceVerifier(req, cookies);
+
+  const { code = "", state = "" } = req.query || {};
+  if (!code || !state || !pkceVerifier) {
+    context.res = { status: 400, headers: { "Content-Type": "application/json", "Set-Cookie": cookies }, body: JSON.stringify({ error: "invalid_callback_params" }) };
+    return;
+  }
+
+  if (!expectedStateCookie.startsWith(state + ":")) {
+    context.res = { status: 400, headers: { "Content-Type": "application/json", "Set-Cookie": cookies }, body: JSON.stringify({ error: "state_mismatch" }) };
+    return;
+  }
+  const returnTo = decodeURIComponent(expectedStateCookie.slice(state.length + 1));
+
+  const body = new URLSearchParams({
+    code: String(code),
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code",
+    code_verifier: pkceVerifier
+  });
+
+  const r = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body
+  });
+
+  const text = await r.text();
+  if (!r.ok) {
+    context.res = { status: 400, headers: { "Set-Cookie": cookies, "Content-Type": "application/json" }, body: JSON.stringify({ error: "token_exchange_failed", details: text.slice(0, 512) }) };
+    return;
+  }
+
+  const tok = JSON.parse(text);
+  const refresh_token = tok.refresh_token;
+  const id_token = tok.id_token;
+  const scope = tok.scope;
+
+  // Parse id_token for sub/email without remote JWKS (best-effort)
+  let sub = "unknown";
+  let email = undefined;
+  try {
+    const parts = String(id_token || "").split(".");
+    if (parts.length === 3) {
+      const payload = JSON.parse(Buffer.from(parts[1], "base64").toString("utf8"));
+      sub = payload.sub || sub;
+      email = payload.email || undefined;
+    }
+  } catch (_) {}
+
+  if (!refresh_token) {
+    context.res = { status: 400, headers: { "Set-Cookie": cookies, "Content-Type": "application/json" }, body: JSON.stringify({ error: "no_refresh_token_returned", note: "Use prompt=consent once and ensure access_type=offline" }) };
+    return;
+  }
+
+  // Issue cookies
+  setRefreshCookie(cookies, { refresh_token, sub, email, scope });
+  const now = Math.floor(Date.now() / 1000);
+  setSessionCookie(cookies, { sub, email, scope, iat: now, exp: now + 3600 });
+
+  context.res = {
+    status: 302,
+    headers: { Location: returnTo || "/", "Set-Cookie": cookies },
+    body: ""
+  };
+};
+

--- a/api/google-login/function.json
+++ b/api/google-login/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "google/login"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-login/index.js
+++ b/api/google-login/index.js
@@ -1,0 +1,53 @@
+const { sha256Base64url, randomId } = require("../_lib/crypto");
+const { setPkceCookie, setStateCookie } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "GET") {
+    context.res = { status: 405, headers: { "Allow": "GET" }, body: "" };
+    return;
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const redirectUri = (process.env.APP_BASE_URL || "") + "/api/google/callback";
+  const scope = process.env.GOOGLE_SCOPES || [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.labels",
+    "https://www.googleapis.com/auth/gmail.readonly"
+  ].join(" ");
+  if (!clientId || !redirectUri) {
+    context.res = { status: 500, body: JSON.stringify({ error: "Missing GOOGLE_CLIENT_ID or APP_BASE_URL" }), headers: { "Content-Type": "application/json" } };
+    return;
+  }
+
+  const codeVerifier = randomId(48);
+  const codeChallenge = sha256Base64url(codeVerifier);
+  const state = randomId(16);
+  const returnTo = (req.query && req.query.return_to) ? String(req.query.return_to) : (process.env.APP_BASE_URL || "/");
+
+  const cookies = [];
+  setPkceCookie(cookies, codeVerifier);
+  setStateCookie(cookies, state + ":" + encodeURIComponent(returnTo));
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope,
+    access_type: "offline",
+    include_granted_scopes: "true",
+    prompt: "consent",
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state
+  });
+
+  context.res = {
+    status: 302,
+    headers: {
+      Location: `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`,
+      "Set-Cookie": cookies
+    },
+    body: ""
+  };
+};
+

--- a/api/google-logout/function.json
+++ b/api/google-logout/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "google/logout"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-logout/index.js
+++ b/api/google-logout/index.js
@@ -1,0 +1,13 @@
+const { clearRefreshCookie, clearSessionCookie } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "POST") {
+    context.res = { status: 405, headers: { "Allow": "POST" }, body: "" };
+    return;
+  }
+  const cookies = [];
+  clearRefreshCookie(cookies);
+  clearSessionCookie(cookies);
+  context.res = { status: 200, headers: { "Set-Cookie": cookies, "Content-Type": "application/json" }, body: JSON.stringify({ ok: true }) };
+};
+

--- a/api/google-me/function.json
+++ b/api/google-me/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "google/me"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-me/index.js
+++ b/api/google-me/index.js
@@ -1,0 +1,15 @@
+const { getSession } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "GET") {
+    context.res = { status: 405, headers: { "Allow": "GET" }, body: "" };
+    return;
+  }
+  const session = getSession(req);
+  if (!session) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ authenticated: false }) };
+    return;
+  }
+  context.res = { status: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ authenticated: true, user: { sub: session.sub, email: session.email }, scope: session.scope }) };
+};
+

--- a/api/google-refresh/function.json
+++ b/api/google-refresh/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "google/refresh"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-refresh/index.js
+++ b/api/google-refresh/index.js
@@ -1,0 +1,51 @@
+const fetch = global.fetch;
+const { getRefreshPayload, setSessionCookie, setRefreshCookie } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "POST") {
+    context.res = { status: 405, headers: { "Allow": "POST" }, body: "" };
+    return;
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    context.res = { status: 500, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "Missing GOOGLE_* envs" }) };
+    return;
+  }
+
+  const payload = getRefreshPayload(req);
+  if (!payload || !payload.refresh_token) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "no_refresh_token" }) };
+    return;
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: payload.refresh_token
+  });
+  const r = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params
+  });
+  const text = await r.text();
+  if (!r.ok) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ error: "refresh_failed", details: text.slice(0, 512) }) };
+    return;
+  }
+  const tok = JSON.parse(text);
+  const now = Math.floor(Date.now() / 1000);
+  const sub = payload.sub || "unknown";
+  const email = payload.email || undefined;
+  const scope = payload.scope || tok.scope;
+  setSessionCookie(context.resHeaders = (context.resHeaders || []), { sub, email, scope, iat: now, exp: now + 3600 });
+  if (tok.refresh_token && tok.refresh_token !== payload.refresh_token) {
+    setRefreshCookie(context.resHeaders, { refresh_token: tok.refresh_token, sub, email, scope });
+  }
+
+  context.res = { status: 200, headers: { "Content-Type": "application/json", "Set-Cookie": context.resHeaders }, body: JSON.stringify({ ok: true, expires_in: tok.expires_in }) };
+};
+

--- a/api/google-tokeninfo/function.json
+++ b/api/google-tokeninfo/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "google/tokeninfo"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}
+

--- a/api/google-tokeninfo/index.js
+++ b/api/google-tokeninfo/index.js
@@ -1,0 +1,18 @@
+const fetch = global.fetch;
+const { getRefreshPayload } = require("../_lib/session");
+
+module.exports = async function (context, req) {
+  if (req.method !== "GET") {
+    context.res = { status: 405, headers: { "Allow": "GET" }, body: "" };
+    return;
+  }
+  const payload = getRefreshPayload(req);
+  if (!payload || !payload.refresh_token) {
+    context.res = { status: 401, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ authenticated: false }) };
+    return;
+  }
+  // We don't expose access token; just show granted scopes by hitting tokeninfo requires an access token.
+  // Instead, return stored scope from cookie payload.
+  context.res = { status: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ authenticated: true, scope: payload.scope || null }) };
+};
+

--- a/api/local.settings.example.json
+++ b/api/local.settings.example.json
@@ -3,7 +3,14 @@
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "OPENAI_API_KEY": "sk-xxxx"
+    "OPENAI_API_KEY": "sk-xxxx",
+    "APP_BASE_URL": "http://localhost:4280",
+    "GOOGLE_CLIENT_ID": "your-google-client-id.apps.googleusercontent.com",
+    "GOOGLE_CLIENT_SECRET": "your-google-client-secret",
+    "GOOGLE_SCOPES": "https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.labels https://www.googleapis.com/auth/gmail.readonly",
+    "COOKIE_SECRET": "change-this-long-random-secret",
+    "COOKIE_SIGNING_SECRET": "change-this-other-secret",
+    "COOKIE_SECURE": "false"
   }
 }
 

--- a/svelte-app/src/lib/queue/flush.ts
+++ b/svelte-app/src/lib/queue/flush.ts
@@ -7,13 +7,7 @@ import { copyGmailDiagnosticsToClipboard } from '$lib/gmail/api';
 import { applyRemoteLabels } from './intents';
 
 export async function flushOnce(now = Date.now()): Promise<void> {
-  // Ensure auth is initialized before attempting any Gmail API calls
-  try {
-    const { getAuthState } = await import('$lib/gmail/auth');
-    const state = getAuthState();
-    // Only proceed if GIS client is ready AND we have a valid, unexpired token in state
-    if (!state.ready || !state.accessToken || !state.expiryMs || state.expiryMs <= Date.now()) return;
-  } catch (_) {}
+  // In server-managed auth mode, we rely on the server session; proceed and handle 401s per-call.
   const db = await getDB();
   const due = await getDueOps(now);
   if (!due.length) return;


### PR DESCRIPTION
Propose a server-side Google authentication architecture to enable longer-lived sessions and secure multi-client/multi-tenant support.

---
<a href="https://cursor.com/background-agent?bcId=bc-278d1b00-8f01-4f67-97e5-c720d0116e3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-278d1b00-8f01-4f67-97e5-c720d0116e3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

